### PR TITLE
fix: support for --mm:refc

### DIFF
--- a/src/wasm3/wasm3c.nim
+++ b/src/wasm3/wasm3c.nim
@@ -95,6 +95,7 @@ accessor(f64, F64, float64)
 
 
 {. push header: "wasm3.h".}
+{. push header: "m3_env.h".}
 type
   Result* = cstring
 

--- a/wasm3.nimble
+++ b/wasm3.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version = "0.1.16"
+version = "0.1.17"
 author        = "jason"
 description   = "A new awesome nimble package"
 license       = "MIT"


### PR DESCRIPTION
Was experiencing issues building a project with `--mm:refc`, turns out refc doesn't like forward declarations and fails on the importc phase (kind of). 

This small fix adds extra header import `m3_env.h` with struct implementations before importing them to nim.